### PR TITLE
Feat/gh pages

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,49 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+      - name: Build with Jekyll
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 

--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,18 @@ __pycache__/
 *.pyd
 *.db
 
-venv
+venv/
+.env/
 
 .sass-cache/
+.jekyll-cache/
+.jekyll-metadata
 
 **/.DS_Store
-_site
+_site/
 
-**/*.egg-info
-
+**/*.egg-info/
 **/*.lock
+
+.bundle/
+vendor/

--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,6 @@ aux_links:
   "View on GitHub":
     - "https://github.com/francois-marie/awesome-qldpc"
 
-
 # Build settings
 markdown: kramdown
 sass:
@@ -22,6 +21,7 @@ sass:
 plugins:
   - jekyll-remote-theme
   - jekyll-include-cache
+  - jekyll-seo-tag
 
 # Just the Docs specific settings
 callouts:
@@ -75,3 +75,6 @@ gh_edit_link_text: "Edit this page on GitHub"
 gh_edit_repository: "https://github.com/francois-marie/awesome-qldpc" # the github URL for your repo
 gh_edit_branch: "main" # the branch that your docs is served from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
+
+# Footer content
+footer_content: "Copyright &copy; 2024 François-Marie Le Régent. Distributed under an MIT license."


### PR DESCRIPTION
This pull request includes changes to automate the deployment of the Jekyll site to GitHub Pages and updates to the `_config.yml` file to enhance the site's configuration. The most important changes include setting up a GitHub Actions workflow for deployment, adding a new plugin, and updating the footer content.

Deployment automation:

* [`.github/workflows/jekyll.yml`](diffhunk://#diff-60ac246cc02819dea1007076ba57241caa7c7d1e8232a5179124d4e63bb366f8R1-R49): Added a new GitHub Actions workflow to automate the deployment of the Jekyll site to GitHub Pages. This includes steps for checking out the repository, setting up Ruby, building the site with Jekyll, and deploying to GitHub Pages.

Configuration updates:

* [`_config.yml`](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883R24): Added the `jekyll-seo-tag` plugin to enhance SEO for the site.
* [`_config.yml`](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883R78-R80): Updated the footer content to include copyright information for 2024.