### PR TITLE
fix gh action

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -5,45 +5,42 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
-          bundler-cache: true
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v4
-      - name: Build with Jekyll
-        run: bundle exec jekyll build
-        env:
-          JEKYLL_ENV: production
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    if: github.ref == 'refs/heads/main'
+    
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4 
+    - name: Checkout main branch first
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        fetch-depth: 0
+    
+    - name: Clean workspace
+      run: |
+        rm -rf _site
+        rm -rf .jekyll-cache
+        rm -rf vendor
+    
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.1'
+        bundler-cache: true
+    
+    - name: Clean Gemfile.lock
+      run: rm -f Gemfile.lock
+    
+    - name: Install dependencies
+      run: |
+        bundle config set --local path 'vendor/bundle'
+        bundle install
+    
+    - name: Build and deploy
+      uses: helaili/jekyll-action@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        target_branch: gh-pages
+        keep_history: true
+        jekyll_build_options: "--trace" 


### PR DESCRIPTION
This pull request includes significant changes to the GitHub Actions workflow for deploying a Jekyll site. The most important changes involve renaming the job, modifying the deployment steps, and updating the Ruby version.

Changes to GitHub Actions workflow:

* [`.github/workflows/jekyll.yml`](diffhunk://#diff-60ac246cc02819dea1007076ba57241caa7c7d1e8232a5179124d4e63bb366f8L8-R46): Renamed the job from `build` to `deploy` and added a condition to run only on the `main` branch.
* [`.github/workflows/jekyll.yml`](diffhunk://#diff-60ac246cc02819dea1007076ba57241caa7c7d1e8232a5179124d4e63bb366f8L8-R46): Removed permissions and concurrency settings, simplifying the workflow configuration.
* [`.github/workflows/jekyll.yml`](diffhunk://#diff-60ac246cc02819dea1007076ba57241caa7c7d1e8232a5179124d4e63bb366f8L8-R46): Added steps to clean the workspace and `Gemfile.lock` before installing dependencies and deploying the site using `helaili/jekyll-action@v2`.
* [`.github/workflows/jekyll.yml`](diffhunk://#diff-60ac246cc02819dea1007076ba57241caa7c7d1e8232a5179124d4e63bb366f8L8-R46): Updated the Ruby version from `3.2` to `3.1`.