### PR TITLE
fix config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,4 +77,4 @@ gh_edit_branch: "main" # the branch that your docs is served from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
 
 # Footer content
-footer_content: "Copyright &copy; 2024 François-Marie Le Régent. Distributed under an MIT license."
+footer_content: "Copyright &copy; 2025 François-Marie Le Régent. Distributed under an MIT license."


### PR DESCRIPTION
This pull request includes a minor update to the `_config.yml` file. The change updates the copyright year in the footer content.

* [`_config.yml`](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L80-R80): Updated the copyright year from 2024 to 2025.