### PR TITLE
Fix/website with new columns

### DIFF
--- a/assets/js/data-loader.js
+++ b/assets/js/data-loader.js
@@ -26,26 +26,59 @@ function initQldpcTable(tableId, pageLength = 10) {
                 const table = $(`#${tableId}`).DataTable({
                     data: results.data,
                     columns: [
-                        { title: "Title", data: "title" },
-                        { title: "n", data: "n" },
-                        { title: "k", data: "k" },
-                        { title: "d", data: "d" },
                         { 
-                            title: "n_a", 
+                            title: "Title",
+                            data: "title"
+                        },
+                        { 
+                            title: "n",
+                            data: "n"
+                        },
+                        { 
+                            title: "k",
+                            data: "k"
+                        },
+                        { 
+                            title: "d",
+                            data: "d"
+                        },
+                        { 
+                            title: "n_a",
                             data: "n_a",
                             render: function(data) {
-                                return data || "?";
+                                return data || "?"
                             }
                         },
                         { 
-                            title: "Reference", 
+                            title: "Pseudo-threshold",
+                            data: "pseudo-threshold",
+                            render: function(data) {
+                                return data || "?"
+                            }
+                        },
+                        { 
+                            title: "Decoder",
+                            data: "decoder",
+                            render: function(data) {
+                                return data || "?"
+                            }
+                        },
+                        { 
+                            title: "Family",
+                            data: "family",
+                            render: function(data) {
+                                return data || "?"
+                            }
+                        },
+                        { 
+                            title: "Reference",
                             data: "doi",
                             render: function(data) {
                                 return data ? `<a href="${data}" target="_blank">Link</a>` : '';
                             }
                         }
                     ],
-                    responsive: true,
+                    responsive: false,
                     pageLength: pageLength,
                     order: [[1, 'desc']], // Sort by n by default
                     dom: 'Bfrtip',

--- a/assets/js/data-loader.js
+++ b/assets/js/data-loader.js
@@ -6,6 +6,15 @@ function initQldpcTable(tableId, pageLength = 10) {
         header: true,
         complete: function(results) {
             console.log(`Loading qLDPC codes data for ${tableId}`);
+            console.log('CSV Headers:', results.meta.fields);
+            console.log('First row:', results.data[0]);
+            
+            // Filter out empty rows
+            results.data = results.data.filter(row => 
+                row['n'] && row['n'].toString().trim() !== '' &&
+                row['k'] && row['k'].toString().trim() !== '' &&
+                row['d'] && row['d'].toString().trim() !== ''
+            );
             
             if (results.data.length === 0 || !results.data[0]) {
                 console.warn('No qLDPC codes data found');

--- a/codes.md
+++ b/codes.md
@@ -17,6 +17,9 @@ This is a comprehensive list of all qLDPC codes in our database.
       <th>k</th>
       <th>d</th>
       <th>n_a</th>
+      <th>Pseudo-threshold</th>
+      <th>Decoder</th>
+      <th>Family</th>
       <th>Reference</th>
     </tr>
   </thead>

--- a/index.md
+++ b/index.md
@@ -21,6 +21,9 @@ A curated list of Quantum Low-Density Parity-Check (qLDPC) codes from theoretica
       <th>k</th>
       <th>d</th>
       <th>n_a</th>
+      <th>Pseudo-threshold</th>
+      <th>Decoder</th>
+      <th>Family</th>
       <th>Reference</th>
     </tr>
   </thead>
@@ -46,4 +49,7 @@ Each entry should include:
 - Number of logical qubits (k)
 - Code distance (d)
 - Number of ancilla qubits (n_a)
+- Pseudo-threshold
+- Decoder type
+- Code family
 - DOI or arXiv link


### PR DESCRIPTION
This pull request includes updates to the `initQldpcTable` function in `assets/js/data-loader.js` and modifications to the `codes.md` and `index.md` files to include new columns in the qLDPC codes data table. The most important changes include filtering out empty rows in the data, adding new columns to the data table, and updating the documentation to reflect these changes.

Enhancements to data processing and table display:

* [`assets/js/data-loader.js`](diffhunk://#diff-3c114d4d13ae28c2a530963ca6f74b6e5522b24ef17df55ab7574ed8aebf7bcaR9-R17): Added logging of CSV headers and first row, and filtered out empty rows to ensure data integrity.
* [`assets/js/data-loader.js`](diffhunk://#diff-3c114d4d13ae28c2a530963ca6f74b6e5522b24ef17df55ab7574ed8aebf7bcaL20-R70): Expanded the data table to include new columns: `Pseudo-threshold`, `Decoder`, and `Family`, with default rendering for missing data.
* [`assets/js/data-loader.js`](diffhunk://#diff-3c114d4d13ae28c2a530963ca6f74b6e5522b24ef17df55ab7574ed8aebf7bcaL39-R81): Changed the `responsive` option of the data table to `false` to better handle the new columns.

Documentation updates:

* [`codes.md`](diffhunk://#diff-2bece76388622b463006813f34fa65eb03fb44634bda2a864253898cd918e635R20-R22): Added new columns `Pseudo-threshold`, `Decoder`, and `Family` to the qLDPC codes table.
* [`index.md`](diffhunk://#diff-a48746cae70c44e7e105b594aad338ddd105c93c1cb445a40ba6aab785ba69e5R24-R26): Updated the list of required entry fields to include `Pseudo-threshold`, `Decoder type`, and `Code family`. [[1]](diffhunk://#diff-a48746cae70c44e7e105b594aad338ddd105c93c1cb445a40ba6aab785ba69e5R24-R26) [[2]](diffhunk://#diff-a48746cae70c44e7e105b594aad338ddd105c93c1cb445a40ba6aab785ba69e5R52-R54)